### PR TITLE
0.3.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ branches:
 
 install:
   - pip install $DJANGO
-  - pip install -e git+git://github.com/openwisp/django-netjsongraph#egg=django-netjsongraph
   - python setup.py -q develop
   - pip install -r requirements-test.txt
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Verison 0.3.0 [2020-02-06]
+--------------------------
+
+- Dropped support python 3.5 and below
+- Dropped support django 2.1 and below
+- Dropped support openwisp-users below 0.2.0
+- Dropped support openwisp-utils 0.4.1 and below
+- Dropped support django-netjsongraph below 0.6.0
+- Added support for django 3.0
+
 Verison 0.2.2 [2020-01-13]
 --------------------------
 

--- a/openwisp_network_topology/__init__.py
+++ b/openwisp_network_topology/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 2, 2, 'final')
+VERSION = (0, 3, 0, 'final')
 __version__ = VERSION  # alias
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django-netjsongraph>=0.5.0,<0.6.0
+django-netjsongraph>=0.6.0,<0.7.0
 openwisp-users>=0.2.0,<0.3
-openwisp-utils>=0.4.0,<0.5.0
+openwisp-utils>=0.4.2,<0.5.0


### PR DESCRIPTION
Verison 0.3.0 [2020-02-06]
--------------------------

- Dropped support python 3.5 and below
- Dropped support django 2.1 and below
- Dropped support openwisp-users below 0.2.0
- Dropped support openwisp-utils 4.1.0 and below
- Dropped support django-netjsongraph below 0.6.0
- Added support for django 3.0

Signed-off-by: Ajay Tripathi <ajay39in@gmail.com>

**Blocked by: django-netjsongraph 0.6.0 PyPi release**