### PR TITLE
0.3.1 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Verison 0.3.1 [2020-02-26]
+--------------------------
+
+- bumped min openwisp-utils 0.4.3
+- bumped django-netjsongraph 0.6.1
+
 Verison 0.3.0 [2020-02-06]
 --------------------------
 

--- a/openwisp_network_topology/__init__.py
+++ b/openwisp_network_topology/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 3, 0, 'final')
+VERSION = (0, 3, 1, 'final')
 __version__ = VERSION  # alias
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django-netjsongraph>=0.6.0,<0.7.0
+django-netjsongraph>=0.6.1,<0.7.0
 openwisp-users>=0.2.0,<0.3
-openwisp-utils>=0.4.2,<0.5.0
+openwisp-utils>=0.4.3,<0.5.0


### PR DESCRIPTION
Verison 0.3.1 [2020-02-26]
--------------------------

- bumped min openwisp-utils 0.4.3
- bumped django-netjsongraph 0.6.1

Signed-off-by: Ajay Tripathi <ajay39in@gmail.com>