### PR TITLE
release 0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ install:
   - pip install $DJANGO
   - python setup.py -q develop
   - pip install -r requirements-test.txt
-  # Temporary, remove when netdiff 0.8.0 is released
-  - pip install --upgrade https://github.com/openwisp/netdiff/tarball/master
 
 script:
   - coverage run --source=openwisp_network_topology runtests.py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,16 @@
 Changelog
 =========
 
-Verison 0.4.0 [2020-06-22]
+Verison 0.4.0 [2020-06-28]
 --------------------------
 
-- Merged openwisp-network-topology & django-netjsongraph
+- [refactoring] Merged code of django-netjsongraph in openwisp-network-topology
 - [**breaking change**]: URLS at ``/api/`` moved to ``/api/v1/``
 - [docs] Reordered & Improved docs
-- [add] requirement swapper~=1.1
+- [add] Requirement swapper~=1.1
 - [docs] Added tutorial for extending openwisp-network-topology
-- [add] upgrader script to upgrade from django-netjsongraph to openwisp-network-topology
-- [add] support for netdiff~=0.8.0
+- [feature] Upgrader script to upgrade from django-netjsongraph to openwisp-network-topology
+- [change] Requirement netdiff~=0.8.0
 
 Verison 0.3.2 [2020-06-02]
 --------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,16 @@
 Changelog
 =========
 
-Verison 0.4.0 [unreleased]
+Verison 0.4.0 [2020-06-22]
 --------------------------
-
-WIP
 
 - Merged openwisp-network-topology & django-netjsongraph
 - [**breaking change**]: URLS at ``/api/`` moved to ``/api/v1/``
 - [docs] Reordered & Improved docs
-- [add] swapper~=1.1
+- [add] requirement swapper~=1.1
 - [docs] Added tutorial for extending openwisp-network-topology
+- [add] upgrader script to upgrade from django-netjsongraph to openwisp-network-topology
+- [add] support for netdiff~=0.8.0
 
 Verison 0.3.2 [2020-06-02]
 --------------------------

--- a/openwisp_network_topology/__init__.py
+++ b/openwisp_network_topology/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 3, 2, 'final')
+VERSION = (0, 4, 0, 'final')
 __version__ = VERSION  # alias
 
 


### PR DESCRIPTION
- Merged openwisp-network-topology & django-netjsongraph
- [**breaking change**]: URLS at ``/api/`` moved to ``/api/v1/``
- [docs] Reordered & Improved docs
- Added requirement swapper~=1.1
- [docs] Added tutorial for extending openwisp-network-topology
- added upgrader script to upgrade from django-netjsongraph to openwisp-network-topology
- add support for netdiff~=0.8.0

Signed-off-by: Ajay Tripathi <ajay39in@gmail.com>