### PR TITLE
[api] /receive/{id}/ > /topology/{id}/receive/ #62

### DIFF
--- a/openwisp_network_topology/tests/test_admin.py
+++ b/openwisp_network_topology/tests/test_admin.py
@@ -130,16 +130,17 @@ class TestAdmin(CreateGraphObjectsMixin, CreateOrgMixin, LoadMixin, TestCase):
         t.save()
         path = reverse('{0}_topology_change'.format(self.prefix), args=[t.pk])
         # No change in URL Test
+        receive_path = f'topology/{t.pk}/receive/'
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'field-receive_url')
-        self.assertContains(response, 'http://testserver/api/v1/receive')
+        self.assertContains(response, f'http://testserver/api/v1/{receive_path}')
         # Change URL Test
         TopologyAdmin.receive_url_baseurl = 'http://changedurlbase'
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'field-receive_url')
-        self.assertContains(response, 'http://changedurlbase/api/v1/receive')
+        self.assertContains(response, f'http://changedurlbase/api/v1/{receive_path}')
         # Change URLConf Test
         TopologyAdmin.receive_url_urlconf = '{}.{}'.format(
             self.module, self.api_urls_path
@@ -147,7 +148,7 @@ class TestAdmin(CreateGraphObjectsMixin, CreateOrgMixin, LoadMixin, TestCase):
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'field-receive_url')
-        self.assertContains(response, 'http://changedurlbase/receive')
+        self.assertContains(response, f'http://changedurlbase/{receive_path}')
         # Reset test options
         TopologyAdmin.receive_url_baseurl = None
         TopologyAdmin.receive_url_urlconf = None

--- a/openwisp_network_topology/utils.py
+++ b/openwisp_network_topology/utils.py
@@ -47,6 +47,11 @@ def get_api_urls(views_module):
         url(
             r'^receive/(?P<pk>[^/\?]+)/$',
             views_module.receive_topology,
+            name='receive_topology_deprecated',
+        ),
+        url(
+            r'^topology/(?P<pk>[^/\?]+)/receive/$',
+            views_module.receive_topology,
             name='receive_topology',
         ),
     ]


### PR DESCRIPTION
Closed issue by renaming /receive/{id}/ to /topology/{id}/receive/
while ensuring backward compatibility with warnings.

Closes #62