### PR TITLE
[fix] Fixed Topology admin for users who do not have delete permission

### DIFF
--- a/openwisp_network_topology/admin.py
+++ b/openwisp_network_topology/admin.py
@@ -114,9 +114,10 @@ class TopologyAdmin(
         move delete action to last position
         """
         actions = super().get_actions(request)
-        delete = actions['delete_selected']
-        del actions['delete_selected']
-        actions['delete_selected'] = delete
+        if 'delete_selected' in actions:
+            delete = actions['delete_selected']
+            del actions['delete_selected']
+            actions['delete_selected'] = delete
         return actions
 
     def change_view(self, request, object_id, form_url='', extra_context=None):

--- a/openwisp_network_topology/tests/test_admin.py
+++ b/openwisp_network_topology/tests/test_admin.py
@@ -3,6 +3,7 @@ import re
 import responses
 import swapper
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.urls import reverse
 
@@ -280,6 +281,10 @@ class TestMultitenantAdmin(
 
     def test_topology_queryset(self):
         data = self._create_multitenancy_test_env()
+        perm = Permission.objects.get_by_natural_key(
+            'delete_topology', self.app_label, self.topology_model.__name__.lower()
+        )
+        data['operator'].user_permissions.remove(perm)
         self._test_multitenant_admin(
             url=reverse(f'admin:{self.app_label}_topology_changelist'),
             visible=[data['t1'].label, data['org1'].name],


### PR DESCRIPTION
Topology admin fails if logged in as user which does not have permission to delete an object.
This patch fixes it.