### PR TITLE
[test] Avoided noisy error logging during tests #132

### DIFF
--- a/openwisp_network_topology/tests/test_admin.py
+++ b/openwisp_network_topology/tests/test_admin.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from openwisp_users.tests.utils import TestMultitenantAdminMixin, TestOrganizationMixin
+from openwisp_utils.tests import capture_any_output
 
 from ..admin import TopologyAdmin
 from .utils import CreateGraphObjectsMixin, CreateOrgMixin, LoadMixin
@@ -83,6 +84,7 @@ class TestAdmin(CreateGraphObjectsMixin, CreateOrgMixin, LoadMixin, TestCase):
         self.assertEqual(self.node_model.objects.count(), 2)
         self.assertEqual(self.link_model.objects.count(), 1)
 
+    @capture_any_output()
     @responses.activate
     def test_update_selected_failed(self):
         t = self.topology_model.objects.first()

--- a/openwisp_network_topology/tests/test_topology.py
+++ b/openwisp_network_topology/tests/test_topology.py
@@ -7,6 +7,8 @@ from django.test import TestCase
 from freezegun import freeze_time
 from netdiff import OlsrParser
 
+from openwisp_utils.tests import capture_any_output
+
 from .utils import CreateGraphObjectsMixin, CreateOrgMixin, LoadMixin
 
 Link = swapper.load_model('topology', 'Link')
@@ -506,6 +508,7 @@ class TestTopology(CreateOrgMixin, CreateGraphObjectsMixin, LoadMixin, TestCase)
         self.assertEqual(t.node_set.all().count(), 13)
         self.assertEqual(t.link_set.all().count(), 11)
 
+    @capture_any_output()
     def test_update_added_items_regression_74_first(self):
         t = self._set_receive(parser='netdiff.OpenvpnParser')
         t.save()


### PR DESCRIPTION
- Used openwisp-utils `@capture_any_output()` to avoid noisy error logging output during tests, Closes #132