### PR TITLE
[test] Updated TestMonitoringIntegration #136

### DIFF
--- a/openwisp_network_topology/integrations/device/tests.py
+++ b/openwisp_network_topology/integrations/device/tests.py
@@ -252,7 +252,7 @@ class TestControllerIntegration(Base, TransactionTestCase):
 
 
 class TestMonitoringIntegration(Base, TransactionTestCase):
-    @mock.patch('openwisp_monitoring.monitoring.apps.MonitoringConfig.create_database')
+    @mock.patch('openwisp_monitoring.db.timeseries_db.create_database')
     @mock.patch('openwisp_monitoring.device.utils.manage_short_retention_policy')
     @mock.patch('openwisp_notifications.types.NOTIFICATION_TYPES', dict())
     def test_monitoring_integration(self, *args):


### PR DESCRIPTION
Due to https://github.com/openwisp/openwisp-monitoring/pull/346
`create_database()` was removed from class `MonitoringConfig`
In result, it raises `AttributeError`, Therefore we need to update this testcase.

Closes #136