### PR TITLE
[chores] Moved organization field in topology list admin to 2nd position

### DIFF
--- a/openwisp_network_topology/admin.py
+++ b/openwisp_network_topology/admin.py
@@ -63,12 +63,12 @@ class TopologyAdmin(
     model = Topology
     list_display = [
         'label',
+        'organization',
         'parser',
         'strategy',
         'published',
         'created',
         'modified',
-        'organization',
     ]
     readonly_fields = [
         'uuid',


### PR DESCRIPTION
For some reason the organization field in the topology list ended up in last position which is not consistent with the rest of the system.