### PR TITLE
[fix] Fixed missing websocket path for non-admin view

### DIFF
--- a/openwisp_network_topology/routing.py
+++ b/openwisp_network_topology/routing.py
@@ -3,8 +3,13 @@ from django.urls import re_path
 from . import consumers
 
 websocket_urlpatterns = [
+    # For topology admin view
     re_path(
         r'^admin/topology/topology/(?P<pk>[^/]+)/change/$',
         consumers.TopologyConsumer.as_asgi(),
-    )
+    ),
+    # For topology non admin view
+    re_path(
+        r'^topology/topology/(?P<pk>[^/]+)/$', consumers.TopologyConsumer.as_asgi()
+    ),
 ]


### PR DESCRIPTION
The `openwisp_network_topology/rounting.py` was missing a websocket path for non-admin view, which caused a `ValueError` to be raised with the message "No route found for path `'topology/topology/<topology:pk>/`"

Fixes #167