### PR TITLE
[fix] Fixed "receive_url" field in TopologyAdmin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -295,7 +295,7 @@ Sending data for topology with RECEIVE strategy
 
    E.g., in our case the URL is ``http://127.0.0.1:8000/api/v1/network-topology/topology/d17e539a-1793-4be2-80a4-c305eca64fd8/receive/?key=cMGsvio8q0L0BGLd5twiFHQOqIEKI423``.
 
-   **Note:** The topology URL is shown only after the topology object is created.
+   **Note:** The topology receive URL is shown only after the topology object is created.
 
 2. Create a script (eg: ``/opt/send-topology.sh``) which sends the topology
    data using ``POST``, in the example script below we are sending the

--- a/README.rst
+++ b/README.rst
@@ -295,6 +295,8 @@ Sending data for topology with RECEIVE strategy
 
    E.g., in our case the URL is ``http://127.0.0.1:8000/api/v1/network-topology/topology/d17e539a-1793-4be2-80a4-c305eca64fd8/receive/?key=cMGsvio8q0L0BGLd5twiFHQOqIEKI423``.
 
+   **Note:** The topology URL is shown only after the topology object is created.
+
 2. Create a script (eg: ``/opt/send-topology.sh``) which sends the topology
    data using ``POST``, in the example script below we are sending the
    status log data of OpenVPN but the same code can be applied to other

--- a/openwisp_network_topology/admin.py
+++ b/openwisp_network_topology/admin.py
@@ -104,6 +104,14 @@ class TopologyAdmin(
     receive_url_baseurl = app_settings.TOPOLOGY_API_BASEURL
     change_form_template = 'admin/topology/topology/change_form.html'
 
+    def get_fields(self, request, obj=None):
+        fields = list(super().get_fields(request, obj))
+        if not obj:
+            # Receive URL cannot be created without an object.
+            # Hence, remove the "receive_url" field.
+            fields.remove('receive_url')
+        return fields
+
     def get_actions(self, request):
         """
         move delete action to last position

--- a/openwisp_network_topology/integrations/device/tests/test_wifi_mesh.py
+++ b/openwisp_network_topology/integrations/device/tests/test_wifi_mesh.py
@@ -266,8 +266,14 @@ class TestWifiMeshIntegration(TopologyTestMixin, TransactionTestCase):
         """
         admin = self._create_admin()
         self.client.force_login(admin)
-        topology = self._create_topology()
-        response = self.client.get(
-            reverse(f'{self.prefix}_topology_change', args=[topology.id])
-        )
-        self.assertContains(response, 'Wifi mesh')
+
+        with self.subTest('Test add form'):
+            response = self.client.get(reverse(f'{self.prefix}_topology_add'))
+            self.assertContains(response, 'Wifi mesh')
+
+        with self.subTest('Test change form'):
+            topology = self._create_topology()
+            response = self.client.get(
+                reverse(f'{self.prefix}_topology_change', args=[topology.id])
+            )
+            self.assertContains(response, 'Wifi mesh')


### PR DESCRIPTION
Bug:
When WiFi Mesh integration is enabled, opening the topology add view was generating Server 500 Error. The issue was caused because the topology instance for the ModelForm didn't have primary key set.

Fix:
Do not show "receive_url" field on add view.