### PR TITLE
[fix] Resolved `TemplateDoesNotExist` error on device page

### DIFF
--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -200,6 +200,7 @@ if not TESTING or (TESTING and os.environ.get('WIFI_MESH', False)):
     )
     openwisp_ipam_index = INSTALLED_APPS.index('openwisp_ipam')
     INSTALLED_APPS.insert(openwisp_ipam_index, 'leaflet')
+    INSTALLED_APPS.insert(openwisp_ipam_index, 'nested_admin')
     INSTALLED_APPS.insert(openwisp_ipam_index, 'openwisp_monitoring.check')
     INSTALLED_APPS.insert(openwisp_ipam_index, 'openwisp_monitoring.device')
     INSTALLED_APPS.insert(openwisp_ipam_index, 'openwisp_monitoring.monitoring')


### PR DESCRIPTION
- Included `nested_admin` app in the settings **INSTALLED_APP**.

![Screenshot from 2023-08-11 17-45-01](https://github.com/openwisp/openwisp-network-topology/assets/56113566/d671e7dc-5451-4970-ad64-29b1f1cfa186)


