### PR TITLE
[fix] Fixed get_name admin short description in device integration

### DIFF
--- a/openwisp_network_topology/integrations/device/overrides.py
+++ b/openwisp_network_topology/integrations/device/overrides.py
@@ -1,4 +1,5 @@
 import swapper
+from django.utils.translation import gettext_lazy as _
 
 Node = swapper.load_model('topology', 'Node')
 Link = swapper.load_model('topology', 'Link')
@@ -107,6 +108,7 @@ def link_get_queryset(cls, qs):
 
 
 Node.get_name = get_name
+Node.get_name.short_description = _('label')
 Node.get_organization_id = node_get_organization_id
 Node.get_queryset = node_get_queryset
 Link.get_queryset = link_get_queryset

--- a/openwisp_network_topology/integrations/device/tests/test_integration.py
+++ b/openwisp_network_topology/integrations/device/tests/test_integration.py
@@ -626,3 +626,8 @@ class TestAdmin(Base, TransactionTestCase):
             reverse(f'{self.prefix}_topology_change', args=[topology.id])
         )
         self.assertNotContains(response, 'Wifi mesh')
+
+    def test_topology_get_name_desc(self):
+        response = self.client.get(reverse(f'{self.prefix}_node_changelist'))
+        self.assertNotContains(response, '<span>Get name</span>', html=True)
+        self.assertContains(response, '<span>Label</span>', html=True)


### PR DESCRIPTION
The `get_name` method override resulted in a non user friendly table heading "Get name" as in the screenshot below.

![Screenshot from 2024-06-13 13-09-20](https://github.com/openwisp/openwisp-network-topology/assets/841044/e5b6f61b-9d15-4199-b366-bb17a81a8882)
