### PR TITLE
Allow closing main About section in visualizer

### DIFF
--- a/openwisp_network_topology/templates/netjsongraph/netjsongraph-script.html
+++ b/openwisp_network_topology/templates/netjsongraph/netjsongraph-script.html
@@ -153,8 +153,33 @@
         }
 
         graph.render();
-        window.initTopologyHistory(django.jQuery);
-        return graph
+
+// Allow closing the About panel
+setTimeout(() => {
+    const aboutPanel = document.querySelector('.njg-panel');
+    if (!aboutPanel) return;
+
+    // Avoid adding the button twice
+    if (aboutPanel.querySelector('.njg-close')) return;
+
+    const closeBtn = document.createElement('span');
+    closeBtn.innerHTML = '&times;';
+    closeBtn.className = 'njg-close';
+    closeBtn.style.cursor = 'pointer';
+    closeBtn.style.float = 'right';
+    closeBtn.style.fontSize = '18px';
+    closeBtn.style.marginLeft = '10px';
+
+    closeBtn.onclick = () => {
+        aboutPanel.style.display = 'none';
+    };
+
+    const header = aboutPanel.querySelector('h3') || aboutPanel;
+    header.prepend(closeBtn);
+}, 0);
+
+window.initTopologyHistory(django.jQuery);
+return graph
 
         // Utility function
         function getTopologyIdFromUrl() {


### PR DESCRIPTION
## Checklist

- [x] I have read the OpenWISP Contributing Guidelines.
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #186

## Description of Changes

This PR adds a close button to the main “About” panel in the network topology visualizer, allowing users to hide it when needed.

The change is minimal, frontend-only, and does not affect existing behavior unless the user explicitly closes the panel.

## Screenshot

N/A
