### PR TITLE
[tests] Fixed mistake in integrations.device test env creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,9 @@ jobs:
 
       - name: Show gecko web driver log on failures
         if: ${{ failure() }}
-        run: cat geckodriver.log
+        run: |
+          [ -f geckodriver.log ] && cat geckodriver.log \
+            || echo "there is no gecko web driver log to show"
 
       - name: Upload Coverage
         if: ${{ success() }}

--- a/openwisp_network_topology/integrations/device/tests/test_integration.py
+++ b/openwisp_network_topology/integrations/device/tests/test_integration.py
@@ -166,7 +166,7 @@ class Base(
             name="VPN2",
             type="vpn",
             vpn=vpn2,
-            config=vpn.auto_client(),
+            config=vpn2.auto_client(),
             default=True,
             organization=organization,
         )


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

The `_create_test_env` method creates 2 VPNs and 1 vpn-client template each, but the second template had a typo and was generating the VPN client config from the first VPN instead of the second, which now, due to recent improvements in the config engine triggered a validation error.

I also took advantage to fix the geckodriver step as in the other repos.