### PR TITLE
[docs] Added WebSocket API reference

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,7 @@ within the OpenWISP architecture.
     ./user/strategies.rst
     ./user/integrations.rst
     ./user/rest-api.rst
+    ./user/websocket-api.rst
     ./user/settings.rst
     ./user/management-commands.rst
 

--- a/docs/user/websocket-api.rst
+++ b/docs/user/websocket-api.rst
@@ -1,0 +1,127 @@
+WebSocket API Reference
+=======================
+
+.. contents:: **Table of contents**:
+    :depth: 2
+    :local:
+
+Overview
+--------
+
+The WebSocket API provides real-time, push-based topology updates.
+
+Current endpoint behavior:
+
+- Use JSON-encoded messages on the wire.
+- Push real-time updates after the connection is established.
+- Do not currently define any client-to-server message contract.
+
+Authentication and Authorization
+--------------------------------
+
+The WebSocket endpoint relies on the standard Django session. When
+authentication is required, connect from a browser context where the user
+is logged in so that the session cookie is sent during the WebSocket
+handshake.
+
+Authorization is controlled by
+``OPENWISP_NETWORK_TOPOLOGY_API_AUTH_REQUIRED``, documented in
+:doc:`settings`.
+
+If the requested topology does not exist or the user is not authorized,
+the connection is closed immediately.
+
+Connection Endpoints
+--------------------
+
+1. Topology Updates
+~~~~~~~~~~~~~~~~~~~
+
+Connection URL:
+
+::
+
+    wss://<host>/ws/network-topology/topology/<topology_id>/
+
+In local development or other non-TLS setups, the ``ws://`` scheme may be
+used instead of ``wss://``.
+
+Scope
++++++
+
+Real-time updates for a single topology identified by ``<topology_id>``.
+
+Authorization
++++++++++++++
+
+When ``OPENWISP_NETWORK_TOPOLOGY_API_AUTH_REQUIRED`` is set to ``True``,
+the connection is accepted only if the user is authorized to view the
+requested topology.
+
+A user is authorized if:
+
+- The user is a superuser, OR
+- The user:
+
+  - Is authenticated,
+  - Is an organization manager for the topology's organization,
+  - Has the ``view_topology`` permission.
+
+If ``OPENWISP_NETWORK_TOPOLOGY_API_AUTH_REQUIRED`` is set to ``False``,
+any client can connect to an existing topology endpoint, including
+unauthenticated users.
+
+Real-time Updates
++++++++++++++++++
+
+When a topology update is broadcast, the server sends a JSON message with
+the following structure:
+
+.. code-block:: javascript
+
+    {
+        "type": "broadcast_topology",
+        "topology": {
+            "...": "topology data"
+        }
+    }
+
+The ``topology`` value contains the current topology representation
+returned by the application, serialized as JSON.
+
+A simplified example looks like this:
+
+.. code-block:: javascript
+
+    {
+        "type": "broadcast_topology",
+        "topology": {
+            "type": "NetworkGraph",
+            "protocol": "netjson.org",
+            "version": "1.0",
+            "nodes": [],
+            "links": []
+        }
+    }
+
+Connected clients receive a new message whenever topology data changes.
+Based on the current implementation and test coverage, updates are sent
+when:
+
+- topology properties change
+- nodes are created, updated, or deleted
+- links are created, updated, or deleted
+
+The connection does not currently expose a request/response message for
+retrieving the current state on demand. Messages are delivered when an
+update event occurs.
+
+Relationship with the REST API
+------------------------------
+
+The WebSocket endpoint complements the :doc:`rest-api` by providing live
+topology updates to connected clients.
+
+Use the REST API when you need to create, retrieve, update, delete, or
+manually submit topology data. Use the WebSocket endpoint when you need to
+observe changes to an existing topology in real time.

--- a/docs/user/websocket-api.rst
+++ b/docs/user/websocket-api.rst
@@ -8,25 +8,26 @@ WebSocket API Reference
 Overview
 --------
 
-The WebSocket API provides real-time, push-based topology updates.
+The WebSocket API provides real-time topology updates.
 
-Current endpoint behavior:
+All endpoints:
 
-- Use JSON-encoded messages on the wire.
+- Use JSON-encoded messages on the wire. The payload examples below are
+  shown in JavaScript-style notation with inline comments for readability.
 - Push real-time updates after the connection is established.
-- Do not currently define any client-to-server message contract.
+- Do not accept client messages: any data sent from the client is ignored.
 
 Authentication and Authorization
 --------------------------------
 
-The WebSocket endpoint relies on the standard Django session. When
-authentication is required, connect from a browser context where the user
-is logged in so that the session cookie is sent during the WebSocket
-handshake.
-
-Authorization is controlled by
+Authentication and authorization are controlled by
 ``OPENWISP_NETWORK_TOPOLOGY_API_AUTH_REQUIRED``, documented in
-:doc:`settings`.
+:doc:`settings`. The setting is enabled by default.
+
+When authentication is required, WebSocket connections rely on the
+standard Django session: connect from a browser context where the user is
+logged in to OpenWISP so that the session cookie is sent during the
+WebSocket handshake.
 
 If the requested topology does not exist or the user is not authorized,
 the connection is closed immediately.
@@ -65,11 +66,22 @@ A user is authorized if:
 
   - Is authenticated,
   - Is an organization manager for the topology's organization,
-  - Has the ``view_topology`` permission.
+  - Has the ``topology.view_topology`` permission.
 
 If ``OPENWISP_NETWORK_TOPOLOGY_API_AUTH_REQUIRED`` is set to ``False``,
 any client can connect to an existing topology endpoint, including
 unauthenticated users.
+
+Client Message
+++++++++++++++
+
+The endpoint does not currently expose a request/response message for
+retrieving the current state on demand. Messages are delivered when an
+update event occurs.
+
+.. warning::
+
+    Any message sent by the client is ignored.
 
 Real-time Updates
 +++++++++++++++++
@@ -80,9 +92,9 @@ the following structure:
 .. code-block:: javascript
 
     {
-        "type": "broadcast_topology",
+        "type": "broadcast_topology",     // Message type identifier
         "topology": {
-            "...": "topology data"
+            "...": "topology data"        // Current topology representation
         }
     }
 
@@ -96,11 +108,11 @@ A simplified example looks like this:
     {
         "type": "broadcast_topology",
         "topology": {
-            "type": "NetworkGraph",
-            "protocol": "netjson.org",
-            "version": "1.0",
-            "nodes": [],
-            "links": []
+            "type": "NetworkGraph",       // NetJSON graph type
+            "protocol": "netjson.org",    // NetJSON protocol identifier
+            "version": "1.0",             // NetJSON version
+            "nodes": [],                  // Topology nodes
+            "links": []                   // Topology links
         }
     }
 
@@ -108,13 +120,9 @@ Connected clients receive a new message whenever topology data changes.
 Based on the current implementation and test coverage, updates are sent
 when:
 
-- topology properties change
-- nodes are created, updated, or deleted
-- links are created, updated, or deleted
-
-The connection does not currently expose a request/response message for
-retrieving the current state on demand. Messages are delivered when an
-update event occurs.
+- Topology properties change.
+- Nodes are created, updated, or deleted.
+- Links are created, updated, or deleted.
 
 Relationship with the REST API
 ------------------------------


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/stable/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #284

## Description of Changes

Added a `docs/user/websocket-api.rst` page documenting the topology WebSocket endpoint and linked it from the docs index.

The new page documents:
- the endpoint URL
- authentication and authorization behavior
- the message structure
- when topology updates are pushed
- the relationship with the existing REST API

I based the documentation on the current implementation and websocket tests to keep it aligned with the actual behavior:
- `openwisp_network_topology/consumers.py`
- `openwisp_network_topology/routing.py`
- `openwisp_network_topology/tests/test_websockets.py`

I also aligned the structure and wording with the existing WebSocket API docs used in sibling OpenWISP modules where applicable.

## Validation

- validated the documented behavior against the current implementation and websocket tests
- ran a Sphinx validation pass for the new page and its local links
