### PR TITLE
[chores] Configure TIMESERIES_DATABASE for monitoring tests

### DIFF
--- a/openwisp_network_topology/integrations/device/tests/test_integration.py
+++ b/openwisp_network_topology/integrations/device/tests/test_integration.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import swapper
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
@@ -479,6 +480,12 @@ class TestControllerIntegration(Base, TransactionTestCase):
 
 
 class TestMonitoringIntegration(Base, TransactionTestCase):
+    def test_timeseries_database_configuration(self):
+        self.assertEqual(
+            settings.TIMESERIES_DATABASE["BACKEND"],
+            "openwisp_monitoring.db.backends.influxdb",
+        )
+
     @mock.patch(
         "openwisp_monitoring.device.apps.DeviceMonitoringConfig.connect_device_signals"
     )

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -181,6 +181,14 @@ ACCOUNT_LOGOUT_REDIRECT_URL = LOGIN_REDIRECT_URL
 OPENWISP_ORGANIZATION_USER_ADMIN = True
 OPENWISP_ORGANIZATION_OWNER_ADMIN = True
 OPENWISP_USERS_AUTH_API = True
+TIMESERIES_DATABASE = {
+    "BACKEND": "openwisp_monitoring.db.backends.influxdb",
+    "USER": "openwisp",
+    "PASSWORD": "openwisp",
+    "NAME": "openwisp2",
+    "HOST": os.getenv("INFLUXDB_HOST", "localhost"),
+    "PORT": "8086",
+}
 
 # Note that the following celery settings
 # are intended only for development purposes
@@ -211,14 +219,6 @@ if not TESTING or (TESTING and os.environ.get("WIFI_MESH", False)):
     INSTALLED_APPS.insert(openwisp_ipam_index, "openwisp_monitoring.check")
     INSTALLED_APPS.insert(openwisp_ipam_index, "openwisp_monitoring.device")
     INSTALLED_APPS.insert(openwisp_ipam_index, "openwisp_monitoring.monitoring")
-    TIMESERIES_DATABASE = {
-        "BACKEND": "openwisp_monitoring.db.backends.influxdb",
-        "USER": "openwisp",
-        "PASSWORD": "openwisp",
-        "NAME": "openwisp2",
-        "HOST": os.getenv("INFLUXDB_HOST", "localhost"),
-        "PORT": "8086",
-    }
     OPENWISP_MONITORING_MAC_VENDOR_DETECTION = False
     CACHES = {
         "default": {


### PR DESCRIPTION
## Checklist

- [x] I have read the OpenWISP Contributing Guidelines and OpenWISP Anti AI Spam Policy.
- N/A. The documented local test environment is not installed in this isolated clone; full CI validates the matrix.
- N/A. This moves existing test settings without changing application code.
- N/A. No user-facing behavior or documentation changed.

## Reference to Existing Issue

Related to #312.

## Description of Changes

Moves the existing `TIMESERIES_DATABASE` test setting outside the WiFi mesh conditional. The Monitoring integration imports its time-series backend even when WiFi mesh is disabled, so the setting must always be available.

## Screenshot

N/A. This is a test-settings change.